### PR TITLE
Update how_update.md 补充binlog_format默认值说明

### DIFF
--- a/mysql/log/how_update.md
+++ b/mysql/log/how_update.md
@@ -298,7 +298,10 @@ binlog 文件是记录了所有数据库表结构变更和表数据修改的日�
 
 *2、文件格式不同：*
 
-- binlog 有 3 种格式类型，分别是 STATEMENT（默认格式）、ROW、 MIXED，区别如下：
+- binlog 有 3 种格式类型，分别是 STATEMENT、ROW、 MIXED，区别如下：
+
+  > 在MySQL 5.7.7之前，`binlog_format`的默认值是`STATEMENT`，而在5.7.7及之后的版本，默认值为`ROW`。
+
   - STATEMENT：每一条修改数据的 SQL 都会被记录到 binlog 中（相当于记录了逻辑操作，所以针对这种格式， binlog 可以称为逻辑日志），主从复制中 slave 端再根据 SQL 语句重现。但 STATEMENT 有动态函数的问题，比如你用了 uuid 或者 now 这些函数，你在主库上执行的结果并不是你在从库执行的结果，这种随时在变的函数会导致复制的数据不一致；
   - ROW：记录行数据最终被修改成什么样了（这种格式的日志，就不能称为逻辑日志了），不会出现 STATEMENT 下动态函数的问题。但 ROW 的缺点是每行数据的变化结果都会被记录，比如执行批量 update 语句，更新多少行数据就会产生多少条记录，使 binlog 文件过大，而在 STATEMENT 格式下只会记录一个 update 语句而已；
   - MIXED：包含了 STATEMENT 和 ROW 模式，它会根据不同的情况自动使用 ROW 模式和 STATEMENT 模式；


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_binlog_format

原话：
> Prior to MySQL 5.7.7, the default format was STATEMENT. In MySQL 5.7.7 and higher, the default is ROW. Exception: In NDB Cluster, the default is MIXED; statement-based replication is not supported for NDB Cluster.
